### PR TITLE
Fix for the "Latest commit does not compile" issue (from branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ For running this on the PS Vita you will first need to extract the runtime shade
 2. Clone the repo: `git clone https://github.com/martepato/sm64-vita.git`, which will create a directory `sm64-vita` and then **enter** it `cd sm64-vita`.
 3. Place a Super Mario 64 ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
 4. Building
-    1. Run `./build_deps.sh` to build and install dependencies. This only has to be done once.
-    2. Run `make TARGET_VITA=1 vpk` to build the game. Add `-j4` to improve build time.
+    1. Run `./build_deps.sh` to build and install old versions of VitaGL and vitaShaRK, needed to keep compatibility. This only has to be done once.
+    2. Run `make TARGET_VITA=1 vpk -j$(nproc)` to build the game.
 5. The installable vpk will be located at `build/us_vita/sm64.<VERSION>.f3dex2e.vpk`
+6. (OPTIONAL) If you need the latest versions of VitaGL and vitaShaRK to compile other projects, you can restore them by running `./restore_latest_deps.sh`.
+              Keep in mind that if you do this you need to rerun the `build_deps.sh` script to allow the compiling of this repo.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Super Mario 64 Port
+# Super Mario 64 Port (Martepato's repo patches + FIX for new VitaSDK releases)
 
 - This repo contains a full decompilation of Super Mario 64 (J), (U), and (E) with minor exceptions in the audio subsystem.
 - Naming and documentation of the source code and data structures are in progress.
@@ -19,7 +19,7 @@ For running this on the PS Vita you will first need to extract the runtime shade
 
 ### Build Instructions
 1. Install [VitaSDK](https://vitasdk.org)
-2. Clone the repo: `git clone https://github.com/martepato/sm64-vita.git`, which will create a directory `sm64-vita` and then **enter** it `cd sm64-vita`.
+2. Clone the repo: `git clone https://github.com/nor2101/sm64-vita_newfix.git`, which will create a directory `sm64-vita` and then **enter** it `cd sm64-vita`.
 3. Place a Super Mario 64 ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
 4. Building
     1. Run `./build_deps.sh` to build and install old versions of VitaGL and vitaShaRK, needed to keep compatibility. This only has to be done once.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For running this on the PS Vita you will first need to extract the runtime shade
 
 ### Build Instructions
 1. Install [VitaSDK](https://vitasdk.org)
-2. Clone the repo: `git clone https://github.com/nor2101/sm64-vita_newfix.git`, which will create a directory `sm64-vita` and then **enter** it `cd sm64-vita`.
+2. Clone the repo: `git clone https://github.com/nor2101/sm64-vita_newfix.git`, which will create a directory `sm64-vita_newfix` and then **enter** it `cd sm64-vita_newfix`.
 3. Place a Super Mario 64 ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
 4. Building
     1. Run `./build_deps.sh` to build and install old versions of VitaGL and vitaShaRK, needed to keep compatibility. This only has to be done once.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Super Mario 64 Port (Martepato's repo patches + FIX for new VitaSDK releases)
+# Super Mario 64 Port
 
 - This repo contains a full decompilation of Super Mario 64 (J), (U), and (E) with minor exceptions in the audio subsystem.
 - Naming and documentation of the source code and data structures are in progress.
@@ -19,7 +19,7 @@ For running this on the PS Vita you will first need to extract the runtime shade
 
 ### Build Instructions
 1. Install [VitaSDK](https://vitasdk.org)
-2. Clone the repo: `git clone https://github.com/nor2101/sm64-vita_newfix.git`, which will create a directory `sm64-vita_newfix` and then **enter** it `cd sm64-vita_newfix`.
+2. Clone the repo: `git clone https://github.com/martepato/sm64-vita.git`, which will create a directory `sm64-vita` and then **enter** it `cd sm64-vita`.
 3. Place a Super Mario 64 ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
 4. Building
     1. Run `./build_deps.sh` to build and install old versions of VitaGL and vitaShaRK, needed to keep compatibility. This only has to be done once.

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -3,12 +3,19 @@
 mkdir deps
 cd deps
 
-# Build and install vitaGL, mathneon and vitaShaRK
+# Build and install old versions of vitaGL and vitaShaRK
 
 git clone https://github.com/Rinnegatamante/vitaGL.git
 cd vitaGL
 git reset --hard 7b9de85
-make HAVE_SBRK=1 HAVE_SHARK=1 install -j4
+make HAVE_SBRK=1 HAVE_SHARK=1 install -j$(nproc)
+cd ..
 
-cd ../../
+git clone https://github.com/Rinnegatamante/vitaShaRK.git
+cd vitaShaRK
+git reset --hard 30e2361
+make install -j$(nproc)
+cd ..
+
+cd ..
 rm -rf deps

--- a/restore_latest_deps.sh
+++ b/restore_latest_deps.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir deps
+cd deps
+
+# Restore default latest versions of these libraries:
+
+git clone https://github.com/Rinnegatamante/vitaGL.git
+cd vitaGL
+make install -j$(nproc)
+cd ..
+
+git clone https://github.com/Rinnegatamante/vitaShaRK.git
+cd vitaShaRK
+make install -j$(nproc)
+cd ..
+
+cd ..
+rm -rf deps


### PR DESCRIPTION
I added the building and downloading of an old commit of the vitaShaRK library to the build_deps.sh script.

This workaround fixes [this issue](https://github.com/martepato/sm64-vita/issues/1) for me, on both Linux and Windows 10 building environments.

I also added another optional script to restore the latest versions of the VitaGL and the vitaShaRK libraries to the $VITASDK path, to keep compatibility with other projects.