### PR TITLE
Fix for current build not compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,6 +520,7 @@ ifeq ($(TARGET_VITA),1)
     -lSceSysmodule_stub -lSceCtrl_stub -lSceTouch_stub -lm \
     -lSceAppUtil_stub -lc -lScePower_stub -lSceCommonDialog_stub \
     -lSceAudio_stub -lSceAudioIn_stub -lSceShaccCg_stub -lSceGxm_stub -lSceDisplay_stub \
+		-lSceShaccCgExt -ltaihen_stub \
     -lSceKernelDmacMgr_stub -lSceIofilemgr_stub -lSceHid_stub -lSceMotion_stub -lm
 endif
 

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -7,6 +7,7 @@ cd deps
 
 git clone https://github.com/Rinnegatamante/vitaGL.git
 cd vitaGL
+git reset --hard 7e155bf
 make HAVE_SHARK=1 install -j4
 
 cd ../../


### PR DESCRIPTION
The latest state of `master` was failing to compile until I made these edits.

First I needed to link SceShaccCgExt and taihen_stub to resolve unresolved symbols errors that they provide.

And second, the latest releases of vitaGL remove the `vglHasRuntimeShaderCompiler` function so I added the git reset the commit just prior to this function being removed.

With these 2 edits I am able to successfully build the .vpk file.